### PR TITLE
Compatibility and persistent memory

### DIFF
--- a/release_badge.svg
+++ b/release_badge.svg
@@ -20,8 +20,8 @@
         <text x="255" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="390" lengthAdjust="spacing">release</text>
         <text x="255" y="140" transform="scale(0.1)" textLength="390" lengthAdjust="spacing">release</text>
     
-    <text x="705" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="350" lengthAdjust="spacing">v1.0.3</text>
-    <text x="705" y="140" transform="scale(0.1)" textLength="350" lengthAdjust="spacing">v1.0.3</text>
+    <text x="705" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="350" lengthAdjust="spacing">v1.0.4</text>
+    <text x="705" y="140" transform="scale(0.1)" textLength="350" lengthAdjust="spacing">v1.0.4</text>
   </g>
 
   

--- a/src/client_communication.cpp
+++ b/src/client_communication.cpp
@@ -1,0 +1,81 @@
+/*
+  Copyright 2019 IQinetics Technologies, Inc support@iq-control.com
+
+  This file is part of the IQ C++ API.
+
+  IQ C++ API is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  IQ C++ API is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+  Name: client_communication.cpp
+  Last update: 4/12/2019 by Matthew Piccoli
+  Author: Matthew Piccoli
+  Contributors: Raphael Van Hoffelen
+*/
+
+#include "client_communication.hpp"
+
+int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
+  ClientEntryAbstract** entry_array, uint8_t entry_length)
+{
+  uint8_t type_idn = rx_data[0];
+  uint8_t sub_idn = rx_data[1];
+  uint8_t obj_idn = rx_data[2] >> 2; // high 6 bits are obj_idn
+  Access dir = static_cast<Access>(rx_data[2] & 0b00000011); // low two bits
+
+  // if we have a reply (we only parse replies here)
+  if(dir == kReply)
+  {
+    // if sub_idn is within array range (safe to access array at this location)
+    if(sub_idn < entry_length)
+    {
+      // if there is a ClientEntry object at this sub_idn
+      if(entry_array[sub_idn] != nullptr)
+      {
+        // if the type and obj identifiers match
+        if(entry_array[sub_idn]->type_idn_ == type_idn &&
+        entry_array[sub_idn]->obj_idn_ == obj_idn)
+        {
+          // ... then we have a valid message
+          entry_array[sub_idn]->Reply(&rx_data[3],rx_length-3);
+          return 1; // I parsed something
+        }
+      }
+    }
+  }
+  return 0; // I didn't parse anything
+}
+
+int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
+  ClientEntryAbstract& entry)
+{
+  uint8_t type_idn = rx_data[0];
+  uint8_t sub_idn = rx_data[1];
+  uint8_t obj_idn = rx_data[2] >> 2; // high 6 bits are obj_idn
+  Access dir = static_cast<Access>(rx_data[2] & 0b00000011); // low two bits
+
+  // if we have a reply (we only parse replies here)
+  if(dir == kReply)
+  {
+    // if the type and obj identifiers match
+    if(entry.type_idn_ == type_idn &&
+    entry.obj_idn_ == obj_idn && entry.sub_idn_ == sub_idn)
+    {
+      // ... then we have a valid message
+      entry.Reply(&rx_data[3],rx_length-3);
+      return 1; // I parsed something
+    }
+  }
+  return 0; // I didn't parse anything
+}

--- a/src/client_communication.hpp
+++ b/src/client_communication.hpp
@@ -19,7 +19,7 @@
 
 /*
   Name: client_communication.hpp
-  Last update: 3/7/2019 by Raphael Van Hoffelen
+  Last update: 4/12/2019 by Matthew Piccoli
   Author: Matthew Piccoli
   Contributors: Raphael Van Hoffelen
 */
@@ -154,57 +154,9 @@ class ClientAbstract{
 };
 
 int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
-  ClientEntryAbstract** entry_array, uint8_t entry_length)
-{
-  uint8_t type_idn = rx_data[0];
-  uint8_t sub_idn = rx_data[1];
-  uint8_t obj_idn = rx_data[2] >> 2; // high 6 bits are obj_idn
-  Access dir = static_cast<Access>(rx_data[2] & 0b00000011); // low two bits
-
-  // if we have a reply (we only parse replies here)
-  if(dir == kReply)
-  {
-    // if sub_idn is within array range (safe to access array at this location)
-    if(sub_idn < entry_length)
-    {
-      // if there is a ClientEntry object at this sub_idn
-      if(entry_array[sub_idn] != nullptr)
-      {
-        // if the type and obj identifiers match
-        if(entry_array[sub_idn]->type_idn_ == type_idn &&
-        entry_array[sub_idn]->obj_idn_ == obj_idn)
-        {
-          // ... then we have a valid message
-          entry_array[sub_idn]->Reply(&rx_data[3],rx_length-3);
-          return 1; // I parsed something
-        }
-      }
-    }
-  }
-  return 0; // I didn't parse anything
-};
+  ClientEntryAbstract** entry_array, uint8_t entry_length);
 
 int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
-  ClientEntryAbstract& entry)
-{
-  uint8_t type_idn = rx_data[0];
-  uint8_t sub_idn = rx_data[1];
-  uint8_t obj_idn = rx_data[2] >> 2; // high 6 bits are obj_idn
-  Access dir = static_cast<Access>(rx_data[2] & 0b00000011); // low two bits
-
-  // if we have a reply (we only parse replies here)
-  if(dir == kReply)
-  {
-    // if the type and obj identifiers match
-    if(entry.type_idn_ == type_idn &&
-    entry.obj_idn_ == obj_idn && entry.sub_idn_ == sub_idn)
-    {
-      // ... then we have a valid message
-      entry.Reply(&rx_data[3],rx_length-3);
-      return 1; // I parsed something
-    }
-  }
-  return 0; // I didn't parse anything
-};
+  ClientEntryAbstract& entry);
 
 #endif // CLIENT_COMMUNICATION_H

--- a/src/iq_module_communicaiton.hpp
+++ b/src/iq_module_communicaiton.hpp
@@ -19,7 +19,7 @@
 
 /*
   Name: iq_module_communication.hpp
-  Last update: 3/7/2019 by Matthew Piccoli
+  Last update: 4/12/2019 by Matthew Piccoli
   Author: Matthew Piccoli
 */
 
@@ -39,3 +39,4 @@
 #include "system_control_client.hpp"
 #include "temperature_monitor_uc_client.hpp"
 #include "temperature_estimator_client.hpp"
+#include "persistent_memory_client.hpp"

--- a/src/iq_serial.hpp
+++ b/src/iq_serial.hpp
@@ -19,7 +19,7 @@
 
 /*
   Name: iq_serial.hpp
-  Last update: 3/9/2019 by Matthew Piccoli
+  Last update: 4/12/2019 by Matthew Piccoli
   Author: Matthew Piccoli
 */
 
@@ -32,11 +32,6 @@ class IqSerial{
     IqSerial(HardwareSerial &my_serial)
     {
       my_serial_ = &my_serial;
-    }
-    
-    IqSerial()
-    {
-      my_serial_ = &Serial;
     }
     
     void begin(unsigned long baud)

--- a/src/persistent_memory_client.hpp
+++ b/src/persistent_memory_client.hpp
@@ -1,0 +1,64 @@
+/*
+  Copyright 2019 IQinetics Technologies, Inc support@iq-control.com
+
+  This file is part of the IQ C++ API.
+
+  IQ C++ API is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  IQ C++ API is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+  Name: persistent_memory_client.hpp
+  Last update: 4/12/2019 by Matthew Piccoli
+  Author: Matthew Piccoli
+  Contributors: Raphael Van Hoffelen
+*/
+
+#ifndef PERSISTENT_MEMORY_CLIENT_HPP_
+#define PERSISTENT_MEMORY_CLIENT_HPP_
+
+#include "client_communication.hpp"
+
+const uint8_t kTypePersistentMemory  =   11;
+
+class PersistentMemoryClient: public ClientAbstract{
+  public:
+    PersistentMemoryClient(uint8_t obj_idn):
+      ClientAbstract(     kTypePersistentMemory, obj_idn),
+      erase_(             kTypePersistentMemory, obj_idn, kSubErase),
+      revert_to_default_( kTypePersistentMemory, obj_idn, kSubRevertToDefault)
+      {};
+
+    // Client Entries
+    // Control commands
+    ClientEntryVoid   erase_;
+    ClientEntryVoid   revert_to_default_;
+
+
+    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    {
+      static const uint8_t kEntryLength = kSubRevertToDefault+1;
+      ClientEntryAbstract* entry_array[kEntryLength] = {
+        &erase_,            // 0
+        &revert_to_default_ // 1
+      };
+
+      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    }
+
+  private:
+    static const uint8_t kSubErase =            0;
+    static const uint8_t kSubRevertToDefault =  1;
+};
+
+#endif /* PERSISTENT_MEMORY_CLIENT_HPP_ */


### PR DESCRIPTION
Adding persistent memory
Removed default constructor for IqSerial
Moved ParseMsg to cpp file so can be compiled by multiple compilation units