### PR TITLE
Update MultiTurnDemo.ino

### DIFF
--- a/examples/MultiTurnDemo/MultiTurnDemo.ino
+++ b/examples/MultiTurnDemo/MultiTurnDemo.ino
@@ -17,7 +17,7 @@
  *  This example code is in the public domain.
  */
 
-#include <iq_module_communicaiton.hpp>
+#include <iq_module_communication.hpp>
 
  // USER SETABLE VALUES HERE---------------------------------------------------
 // Sets the angle to go to in radians
@@ -26,8 +26,8 @@ const float kAngle = 12.0f*PI;
 const float kTime = 5;
 // END USER SETABLE VALUES-----------------------------------------------------
 
-// Make an IqSerial object using Serial0 (same as Serial)
-IqSerial ser(Serial);
+// Make an IqSerial object using Serial1
+IqSerial ser(Serial1);
 // Make a MultiTurnAngleControlClient to interface with a motor module (ID 0)
 MultiTurnAngleControlClient angle(0);
 
@@ -55,7 +55,7 @@ void loop() {
   {
     // Gets ctrl_mode_ from the module and puts the result in the mode variable
     ser.get(angle.ctrl_mode_, mode);
-  }while(mode == 4); // Check if the motor is still executing the last trajectory
+  }while(mode == 6); // Check if the motor is still executing the last trajectory
   
   // Send next message
   if(spin_direction == 1)


### PR DESCRIPTION
- Spelling error in header file name, sadly this is a breaking fix as the file name in the SRC directory is also misspelled.
- Serial and Serial0 are not valid constructor calls to hardware serial on the Arduino platform.
- The mode, in line 58, should be 6. See 2.3.4 Message Table on page 10 of the IQ2306_communication_manual_position_firmware.pdf.

Tested on 
Win_10_x64
Teensy 3.2
Arduino IDE 1.8.8
Teensyduino 1.45

IQ Firmware: stepdir
Version:10