### PR TITLE
duplicate power monitor client bugfix

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -1,3 +1,4 @@
 # Contributors to this library
 
 * **Raphael Van Hoffelen** -*work*- Helped set up repo and its architecture
+* **Ben Quan** -*work*- Currently maintining repo

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IQ Module Communication
-version=1.2.0
+version=1.2.1
 author=Matthew Piccoli <matt.piccoli@vertiq.co>, Raphael Van Hoffelen <raf@iq-control.com>
 maintainer=Matthew Piccoli <matt.piccoli@vertiq.co>, Ben Quan <ben.quan@vertiq.co>
 sentence=A library for communicating with and controlling IQ motor modules.
@@ -7,4 +7,4 @@ paragraph=This uses a Serial port to control the motor modules and get/set/save 
 category=Device Control
 url=https://github.com/iq-motion-control/iq-module-communication-arduino
 architectures=*
-includes=iq_module_communicaiton.hpp
+includes=iq_module_communication.hpp

--- a/src/persistent_memory_client.hpp
+++ b/src/persistent_memory_client.hpp
@@ -8,7 +8,7 @@
 
 /*
   Name: persistent_memory_client.hpp
-  Last update: 9/19/2022 by Ben Quan 
+  Last update: 10/31/2022 by Ben Quan 
   Author: Matthew Piccoli
   Contributors: Ben Quan, Raphael Van Hoffelen
 */
@@ -20,9 +20,9 @@
 
 const uint8_t kTypePersistentMemory  =   11;
 
-class PowerMonitorClient: public ClientAbstract{
+class PersistentMemoryClient: public ClientAbstract{
   public:
-    PowerMonitorClient(uint8_t obj_idn):
+    PersistentMemoryClient(uint8_t obj_idn):
       ClientAbstract(     kTypePersistentMemory, obj_idn),
       erase_(             kTypePersistentMemory, obj_idn, kSubErase),
       revert_to_default_( kTypePersistentMemory, obj_idn, kSubRevertToDefault),

--- a/src/power_monitor_client.hpp
+++ b/src/power_monitor_client.hpp
@@ -3,25 +3,14 @@
 
   This file is part of the IQ C++ API.
 
-  IQ C++ API is free software: you can redistribute it and/or modify
-  it under the terms of the GNU Lesser General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  IQ C++ API is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  GNU Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public License
-  along with this program. If not, see <http://www.gnu.org/licenses/>.
+  This code is licensed under the MIT license (see LICENSE or https://opensource.org/licenses/MIT for details)
 */
 
 /*
   Name: power_monitor_client.hpp
-  Last update: 3/7/2019 by Raphael Van Hoffelen
+  Last update: 09/16/2022 by Ben Quan
   Author: Matthew Piccoli
-  Contributors: Raphael Van Hoffelen
+  Contributors: Ben Quan, Raphael Van Hoffelen
 */
 
 #ifndef POWER_MONITOR_CLIENT_HPP_
@@ -51,18 +40,18 @@ class PowerMonitorClient: public ClientAbstract{
 
     // Client Entries
     // Control commands
-    ClientEntry<float>    volts_;
-    ClientEntry<float>    amps_;
-    ClientEntry<float>    watts_;
-    ClientEntry<float>    joules_;
-    ClientEntryVoid       reset_joules_;
-    ClientEntry<uint32_t> filter_fs_;
-    ClientEntry<uint32_t> filter_fc_;
-    ClientEntry<uint16_t> volts_raw_;
-    ClientEntry<uint16_t> amps_raw_;
-    ClientEntry<float>    volts_gain_;
-    ClientEntry<float>    amps_gain_;
-    ClientEntry<float>    amps_bias_;
+    ClientEntry<float>      volts_;
+    ClientEntry<float>      amps_;
+    ClientEntry<float>      watts_;
+    ClientEntry<float>      joules_;
+    ClientEntryVoid         reset_joules_;
+    ClientEntry<uint32_t>   filter_fs_;
+    ClientEntry<uint32_t>   filter_fc_;
+    ClientEntry<uint16_t>   volts_raw_;
+    ClientEntry<uint16_t>   amps_raw_;
+    ClientEntry<float>      volts_gain_;
+    ClientEntry<float>      amps_gain_;
+    ClientEntry<float>      amps_bias_;
 
     void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
     {
@@ -86,18 +75,18 @@ class PowerMonitorClient: public ClientAbstract{
     }
 
   private:
-    static const uint8_t kSubVolts =      0;
-    static const uint8_t kSubAmps =       1;
-    static const uint8_t kSubWatts =      2;
-    static const uint8_t kSubJoules =     3;
-    static const uint8_t kSubResetJoules =4;
-    static const uint8_t kSubFilterFs =   5;
-    static const uint8_t kSubFilterFc =   6;
-    static const uint8_t kSubVoltsRaw =   7;
-    static const uint8_t kSubAmpsRaw =    8;
-    static const uint8_t kSubVoltsGain =  9;
-    static const uint8_t kSubAmpsGain =   10;
-    static const uint8_t kSubAmpsBias =   11;
+    static const uint8_t kSubVolts        =  0;
+    static const uint8_t kSubAmps         =  1;
+    static const uint8_t kSubWatts        =  2;
+    static const uint8_t kSubJoules       =  3;
+    static const uint8_t kSubResetJoules  =  4;
+    static const uint8_t kSubFilterFs     =  5;
+    static const uint8_t kSubFilterFc     =  6;
+    static const uint8_t kSubVoltsRaw     =  7;
+    static const uint8_t kSubAmpsRaw      =  8;
+    static const uint8_t kSubVoltsGain    =  9;
+    static const uint8_t kSubAmpsGain     = 10;
+    static const uint8_t kSubAmpsBias     = 11;
 };
 
 #endif /* POWER_MONITOR_CLIENT_HPP_ */


### PR DESCRIPTION
- Changed class declaration from PowerMonitorClient to PersistentMemoryClient in persistent_memory_client.hpp
- Reformatted power_monitor_client.hpp
- Updated library.properties