### PR TITLE
Move documentation link to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This is the library to control a IQ Motion Control Module with an Arduino
 
 ## Getting Started
 
-You can download the latest stable release of this library on the arduino IDE [library manager](https://www.arduino.cc/en/guide/libraries). Just look up "IQ Module Communication".  Read the programming [documentation](http://www.iq-control.com/documentation) on our website to learn how to use this library.  
+You can download the latest stable release of this library on the arduino IDE [library manager](https://www.arduino.cc/en/guide/libraries). Just look up "IQ Module Communication".  Read the programming [documentation](https://iqmotion.readthedocs.io/en/latest/langs/arduino.html) on our website to learn how to use this library.  
 A .zip of the library can also be found on our [release page](https://github.com/iq-motion-control/iq-module-communication-arduino/releases). Follow these [instructions](https://www.arduino.cc/en/guide/libraries#toc4) to install a library manually.  
-Read the programming [documentation](https://iqmotion.readthedocs.io/en/latest/langs/arduino.html) on our website to learn how to use this library.  
+Read the programming [documentation](https://www.iq-control.com/support) on our website to learn how to use this library.  
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the library to control a IQ Motion Control Module with an Arduino
 
 You can download the latest stable release of this library on the arduino IDE [library manager](https://www.arduino.cc/en/guide/libraries). Just look up "IQ Module Communication".  Read the programming [documentation](http://www.iq-control.com/documentation) on our website to learn how to use this library.  
 A .zip of the library can also be found on our [release page](https://github.com/iq-motion-control/iq-module-communication-arduino/releases). Follow these [instructions](https://www.arduino.cc/en/guide/libraries#toc4) to install a library manually.  
-Read the programming [documentation](https://www.iq-control.com/support) on our website to learn how to use this library.  
+Read the programming [documentation](https://iqmotion.readthedocs.io/en/latest/langs/arduino.html) on our website to learn how to use this library.  
 
 ### Prerequisites
 


### PR DESCRIPTION
The documentation link in README.md links to a 404. I have moved the link to the readthedocs.io link: https://iqmotion.readthedocs.io/en/latest/langs/arduino.html

Note: on https://www.vertiq.co/ the 404 page's text in white on a white background, thus the text is not visible